### PR TITLE
Improved Settings String Versioning and small Optimizations

### DIFF
--- a/NEO-TWEWY-Randomizer.csproj
+++ b/NEO-TWEWY-Randomizer.csproj
@@ -118,6 +118,9 @@
     <Compile Include="Randomizer\Randomizer\Enums\PinBrand.cs" />
     <Compile Include="Randomizer\Randomizer\Enums\PinGrowth.cs" />
     <Compile Include="Randomizer\Randomizer\RandomizationLogger.cs" />
+    <Compile Include="Randomizer\Randomizer\SettingsString\SettingsStringValue.cs" />
+    <Compile Include="Randomizer\Randomizer\SettingsString\SettingsStringVersion.cs" />
+    <Compile Include="Randomizer\Randomizer\SettingsString\SettingsStringVersionList.cs" />
     <Compile Include="Randomizer\UI\Forms\FormAbout.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -1151,6 +1154,8 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Icons\ID001_NoBrand.ico" />
+    <None Include="Resources\settings_string_versions.json" />
+    <None Include="Resources\settings_string_versions.txt" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.7.2">

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -3417,6 +3417,15 @@ namespace NEO_TWEWY_Randomizer.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string settings_string_versions {
+            get {
+                return ResourceManager.GetString("settings_string_versions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to   Limited Pins for Dropped Pins
         ///Include Pins that have a limited quantity in vanilla (Axion, Dilaton, Dibaryon, and Sfermion)..
         /// </summary>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -1096,6 +1096,9 @@
   <data name="id_list" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\id_list.json;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
+  <data name="settings_string_versions" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\settings_string_versions.json;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
   <data name="ttcheckItemsLimited" xml:space="preserve">
     <value>  Limited Pins for Dropped Pins
 Include Pins that have a limited quantity in vanilla (Axion, Dilaton, Dibaryon, and Sfermion).</value>

--- a/Randomizer/Randomizer/RandomizationSettings.cs
+++ b/Randomizer/Randomizer/RandomizationSettings.cs
@@ -47,6 +47,7 @@ namespace NEO_TWEWY_Randomizer
         public RandomizationSettings()
         {
             InitializeDataStructures();
+            CorrectSettingValues();
         }
 
         private void InitializeDataStructures()
@@ -151,7 +152,9 @@ namespace NEO_TWEWY_Randomizer
         {
             InitializeDataStructures();
 
-            if (Validator.ValidateSettingsString(settingsString) == Validator.SettingsStringValidationResult.Valid)
+            Validator.SettingsStringValidationResult validationResult = Validator.ValidateSettingsString(settingsString);
+
+            if (validationResult == Validator.SettingsStringValidationResult.Valid || validationResult == Validator.SettingsStringValidationResult.WrongVersion)
             {
                 settingsString = settingsString.PadLeft(Validator.SettingsStringMinimumLength, '0');
 
@@ -213,9 +216,9 @@ namespace NEO_TWEWY_Randomizer
                 PinEvoForceBrand = GetBitsFromSettingsString(settingsString, versionInfo, "pin_evo_force") == 1;
                 PinRemoveCharaEvos = GetBitsFromSettingsString(settingsString, versionInfo, "pin_evo_chara") == 1;
                 PinEvoPercentage = GetBitsFromSettingsString(settingsString, versionInfo, "pin_evo_percent");
-
-                CorrectSettingValues();
             }
+
+            CorrectSettingValues();
         }
 
         public string GenerateSettingsString()

--- a/Randomizer/Randomizer/SettingsString/SettingsStringValue.cs
+++ b/Randomizer/Randomizer/SettingsString/SettingsStringValue.cs
@@ -10,9 +10,9 @@ namespace NEO_TWEWY_Randomizer
     class SettingsStringValue
     {
         [JsonProperty("offset")]
-        public uint Offset { get; set; }
+        public int Offset { get; set; }
         [JsonProperty("size")]
-        public uint Size { get; set; }
+        public int Size { get; set; }
         [JsonProperty("name")]
         public string Name { get; set; }
     }

--- a/Randomizer/Randomizer/SettingsString/SettingsStringValue.cs
+++ b/Randomizer/Randomizer/SettingsString/SettingsStringValue.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NEO_TWEWY_Randomizer
+{
+    class SettingsStringValue
+    {
+        [JsonProperty("offset")]
+        public uint Offset { get; set; }
+        [JsonProperty("size")]
+        public uint Size { get; set; }
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/Randomizer/Randomizer/SettingsString/SettingsStringVersion.cs
+++ b/Randomizer/Randomizer/SettingsString/SettingsStringVersion.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NEO_TWEWY_Randomizer
+{
+    class SettingsStringVersion
+    {
+        [JsonProperty("values")]
+        public Dictionary<string, SettingsStringValue> Values { get; set; }
+        [JsonProperty("version")]
+        public uint Version { get; set; }
+        [JsonProperty("changed_values")]
+        public IList<string> ChangedValues { get; set; }
+    }
+}

--- a/Randomizer/Randomizer/SettingsString/SettingsStringVersionList.cs
+++ b/Randomizer/Randomizer/SettingsString/SettingsStringVersionList.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NEO_TWEWY_Randomizer
+{
+    class SettingsStringVersionList
+    {
+        [JsonProperty("versions")]
+        public IList<SettingsStringVersion> Items { get; set; }
+    }
+}

--- a/Randomizer/UI/Forms/FormMain.cs
+++ b/Randomizer/UI/Forms/FormMain.cs
@@ -600,9 +600,7 @@ namespace NEO_TWEWY_Randomizer
             switch (validationResult)
             {
                 case Validator.SettingsStringValidationResult.Valid:
-                    RandomizationSettings settings = new RandomizationSettings(textSettingStringString.Text);
-                    ReadSettings(settings);
-                    MessageBox.Show("Your settings have been imported successfully.", "Settings Imported", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    ImportSettings();
                     break;
                 case Validator.SettingsStringValidationResult.Empty:
                     MessageBox.Show("The Settings String is empty.", "Settings String Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -610,10 +608,36 @@ namespace NEO_TWEWY_Randomizer
                 case Validator.SettingsStringValidationResult.NotHex:
                     MessageBox.Show("There was an error parsing the settings string. It must be a hexadecimal number.", "Settings String Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     break;
+                case Validator.SettingsStringValidationResult.InvalidVersion:
+                    MessageBox.Show("This settings string is either for a newer version of the randomizer, or for an invalid version. Please use a different settings string.", "Settings String Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    break;
                 case Validator.SettingsStringValidationResult.WrongVersion:
-                    MessageBox.Show("This settings string is for a different version of the randomizer. Please manually select your settings and generate a new one.", "Settings String Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    string incorrectSettings = string.Join(", ", GetIncompatibleSettings());
+                    if (MessageBox.Show(string.Format("This settings string is for an older version of the randomizer. The values for these settings might be incorrect: {0}. Are you sure you want to import these settings?", incorrectSettings), "Settings String Warning", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
+                    {
+                        ImportSettings();
+                    }
                     break;
             }
+        }
+
+        private void ImportSettings()
+        {
+            RandomizationSettings settings = new RandomizationSettings(textSettingStringString.Text);
+            try
+            {
+                ReadSettings(settings);
+                MessageBox.Show("Your settings have been imported successfully.", "Settings Imported", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(string.Format("There was an error while importing these settings. Please use a different settings string.\nFull Error:\n{0}", ex.Message), "Error in Settings Import", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private List<string> GetIncompatibleSettings()
+        {
+            return Validator.GetIncompatibleSettings(textSettingStringString.Text);
         }
 
         private void GenerateNewSeed()

--- a/Randomizer/UI/PinImages.cs
+++ b/Randomizer/UI/PinImages.cs
@@ -23,10 +23,9 @@ namespace NEO_TWEWY_Randomizer
 
         public Image GetRandomImage()
         {
-            ResourceSet resourceSet = Resources.ResourceManager.GetResourceSet(CultureInfo.CurrentCulture, true, true);
-            var pins = resourceSet.Cast<DictionaryEntry>().Where(x => x.Value.GetType() == typeof(Bitmap));
-            Bitmap selectedPin = (Bitmap)pins.ElementAt(rand.Next(pins.Count())).Value;
-            return selectedPin;
+            int index = rand.Next(FileConstants.ItemNames.RandoPinImages.Count());
+            Bitmap pin = (Bitmap) Resources.ResourceManager.GetObject(FileConstants.ItemNames.RandoPinImages[index].Name);
+            return pin;
         }
     }
 }

--- a/Randomizer/Utils/FileConstants/FileConstants.cs
+++ b/Randomizer/Utils/FileConstants/FileConstants.cs
@@ -12,6 +12,7 @@ namespace NEO_TWEWY_Randomizer
     {
         public static Dictionary<string, DataBundle> Bundles { get; } = JsonConvert.DeserializeObject<Dictionary<string, DataBundle>>(Resources.bundle_constants);
         public static EnemyDuplicateList EnemyDataDuplicates { get; } = JsonConvert.DeserializeObject<EnemyDuplicateList>(Resources.enemy_sets);
+        public static SettingsStringVersionList SettingsStringVersions { get; } = JsonConvert.DeserializeObject<SettingsStringVersionList>(Resources.settings_string_versions);
         public static ItemNames ItemNames { get; } = JsonConvert.DeserializeObject<ItemNames>(Resources.id_list);
         public static string TextDataBundleKey { get; } = "text-data";
         public static string EnemyDataClassName { get; } = "EnemyData";

--- a/Randomizer/Utils/FileConstants/ItemNames.cs
+++ b/Randomizer/Utils/FileConstants/ItemNames.cs
@@ -31,5 +31,7 @@ namespace NEO_TWEWY_Randomizer
         public IList<NameAssociation> PinAbilities { get; set; }
         [JsonProperty("characters")]
         public IList<NameAssociation> Characters { get; set; }
+        [JsonProperty("rando-pin-images")]
+        public IList<NameAssociation> RandoPinImages { get; set; }
     }
 }

--- a/Randomizer/Utils/Validator.cs
+++ b/Randomizer/Utils/Validator.cs
@@ -14,6 +14,7 @@ namespace NEO_TWEWY_Randomizer
             TooShort,
             NotHex,
             WrongVersion,
+            InvalidVersion,
             Empty
         }
 
@@ -32,9 +33,31 @@ namespace NEO_TWEWY_Randomizer
             if (settingsString.Length <= 0) return SettingsStringValidationResult.Empty;
 
             int version = int.Parse(settingsString.Substring(settingsString.Length - 1, 1), System.Globalization.NumberStyles.HexNumber);
+            if (version >= FileConstants.SettingsStringVersions.Items.Count) return SettingsStringValidationResult.InvalidVersion;
             if (version != SettingsStringVersion) return SettingsStringValidationResult.WrongVersion;
 
             return SettingsStringValidationResult.Valid;
+        }
+
+        public static List<string> GetIncompatibleSettings(string settingsString)
+        {
+            int version = int.Parse(settingsString.Substring(settingsString.Length - 1, 1), System.Globalization.NumberStyles.HexNumber);
+            if (version < FileConstants.SettingsStringVersions.Items.Count)
+            {
+                SettingsStringVersion versionInfo = FileConstants.SettingsStringVersions.Items[version];
+                IEnumerable<string> changedSettings = new List<string>();
+
+                foreach (SettingsStringVersion v in FileConstants.SettingsStringVersions.Items.Where(x => x.Version > version && x.Version <= SettingsStringVersion))
+                {
+                    changedSettings = changedSettings.Union(v.ChangedValues);
+                }
+
+                return changedSettings.ToList();
+            }
+            else
+            {
+                return new List<string>();
+            }
         }
     }
 }

--- a/Resources/id_list.json
+++ b/Resources/id_list.json
@@ -2088,5 +2088,1299 @@
 			"id": 7,
 			"name": "Minamimoto"
 		}
+	],
+	"rando-pin-images": [
+		{
+			"id": 1,
+			"name": "ID001_NoBrand"
+		},
+		{
+			"id": 2,
+			"name": "ID002_JupiterOfTheMonkey"
+		},
+		{
+			"id": 3,
+			"name": "ID003_JupiterOfTheMonkey"
+		},
+		{
+			"id": 4,
+			"name": "ID004_JupiterOfTheMonkey"
+		},
+		{
+			"id": 5,
+			"name": "ID005_JupiterOfTheMonkey"
+		},
+		{
+			"id": 6,
+			"name": "ID006_JupiterOfTheMonkey"
+		},
+		{
+			"id": 7,
+			"name": "ID007_JupiterOfTheMonkey"
+		},
+		{
+			"id": 8,
+			"name": "ID008_JupiterOfTheMonkey"
+		},
+		{
+			"id": 9,
+			"name": "ID009_NoBrand"
+		},
+		{
+			"id": 10,
+			"name": "ID010_JupiterOfTheMonkey"
+		},
+		{
+			"id": 11,
+			"name": "ID011_JupiterOfTheMonkey"
+		},
+		{
+			"id": 12,
+			"name": "ID012_JupiterOfTheMonkey"
+		},
+		{
+			"id": 13,
+			"name": "ID013_JupiterOfTheMonkey"
+		},
+		{
+			"id": 14,
+			"name": "ID014_JupiterOfTheMonkey"
+		},
+		{
+			"id": 15,
+			"name": "ID015_croakypanic"
+		},
+		{
+			"id": 16,
+			"name": "ID016_JupiterOfTheMonkey"
+		},
+		{
+			"id": 17,
+			"name": "ID017_JupiterOfTheMonkey"
+		},
+		{
+			"id": 18,
+			"name": "ID018_JupiterOfTheMonkey"
+		},
+		{
+			"id": 19,
+			"name": "ID019_JupiterOfTheMonkey"
+		},
+		{
+			"id": 20,
+			"name": "ID020_TigrePUNKS"
+		},
+		{
+			"id": 21,
+			"name": "ID021_TigrePUNKS"
+		},
+		{
+			"id": 22,
+			"name": "ID022_TigrePUNKS"
+		},
+		{
+			"id": 23,
+			"name": "ID023_TigrePUNKS"
+		},
+		{
+			"id": 24,
+			"name": "ID024_TigrePUNKS"
+		},
+		{
+			"id": 25,
+			"name": "ID025_TigrePUNKS"
+		},
+		{
+			"id": 26,
+			"name": "ID026_TigrePUNKS"
+		},
+		{
+			"id": 27,
+			"name": "ID027_TigrePUNKS"
+		},
+		{
+			"id": 28,
+			"name": "ID028_TigrePUNKS"
+		},
+		{
+			"id": 29,
+			"name": "ID029_TigrePUNKS"
+		},
+		{
+			"id": 30,
+			"name": "ID030_TigrePUNKS"
+		},
+		{
+			"id": 31,
+			"name": "ID031_TigrePUNKS"
+		},
+		{
+			"id": 32,
+			"name": "ID032_NoBrand"
+		},
+		{
+			"id": 33,
+			"name": "ID033_MONOCROW"
+		},
+		{
+			"id": 34,
+			"name": "ID034_MONOCROW"
+		},
+		{
+			"id": 35,
+			"name": "ID035_MONOCROW"
+		},
+		{
+			"id": 36,
+			"name": "ID036_MONOCROW"
+		},
+		{
+			"id": 37,
+			"name": "ID037_MONOCROW"
+		},
+		{
+			"id": 38,
+			"name": "ID038_MONOCROW"
+		},
+		{
+			"id": 39,
+			"name": "ID039_MONOCROW"
+		},
+		{
+			"id": 40,
+			"name": "ID040_MONOCROW"
+		},
+		{
+			"id": 41,
+			"name": "ID041_MONOCROW"
+		},
+		{
+			"id": 42,
+			"name": "ID042_NoBrand"
+		},
+		{
+			"id": 43,
+			"name": "ID043_MONOCROW"
+		},
+		{
+			"id": 44,
+			"name": "ID044_MONOCROW"
+		},
+		{
+			"id": 45,
+			"name": "ID045_MONOCROW"
+		},
+		{
+			"id": 46,
+			"name": "ID046_MONOCROW"
+		},
+		{
+			"id": 47,
+			"name": "ID047_MONOCROW"
+		},
+		{
+			"id": 48,
+			"name": "ID048_NoBrand"
+		},
+		{
+			"id": 49,
+			"name": "ID049_NATURALPUPPY"
+		},
+		{
+			"id": 50,
+			"name": "ID050_NATURALPUPPY"
+		},
+		{
+			"id": 51,
+			"name": "ID051_NATURALPUPPY"
+		},
+		{
+			"id": 52,
+			"name": "ID052_NATURALPUPPY"
+		},
+		{
+			"id": 53,
+			"name": "ID053_NATURALPUPPY"
+		},
+		{
+			"id": 54,
+			"name": "ID054_NATURALPUPPY"
+		},
+		{
+			"id": 55,
+			"name": "ID055_NATURALPUPPY"
+		},
+		{
+			"id": 56,
+			"name": "ID056_NATURALPUPPY"
+		},
+		{
+			"id": 57,
+			"name": "ID057_NATURALPUPPY"
+		},
+		{
+			"id": 58,
+			"name": "ID058_NoBrand"
+		},
+		{
+			"id": 59,
+			"name": "ID059_NATURALPUPPY"
+		},
+		{
+			"id": 60,
+			"name": "ID060_NATURALPUPPY"
+		},
+		{
+			"id": 61,
+			"name": "ID061_NATURALPUPPY"
+		},
+		{
+			"id": 62,
+			"name": "ID062_NATURALPUPPY"
+		},
+		{
+			"id": 63,
+			"name": "ID063_NATURALPUPPY"
+		},
+		{
+			"id": 64,
+			"name": "ID064_croakypanic"
+		},
+		{
+			"id": 65,
+			"name": "ID065_croakypanic"
+		},
+		{
+			"id": 66,
+			"name": "ID066_MONOCROW"
+		},
+		{
+			"id": 67,
+			"name": "ID067_MONOCROW"
+		},
+		{
+			"id": 68,
+			"name": "ID068_MONOCROW"
+		},
+		{
+			"id": 69,
+			"name": "ID069_MONOCROW"
+		},
+		{
+			"id": 70,
+			"name": "ID070_MONOCROW"
+		},
+		{
+			"id": 71,
+			"name": "ID071_MONOCROW"
+		},
+		{
+			"id": 72,
+			"name": "ID072_NoBrand"
+		},
+		{
+			"id": 73,
+			"name": "ID073_ConyCony"
+		},
+		{
+			"id": 74,
+			"name": "ID074_ConyCony"
+		},
+		{
+			"id": 75,
+			"name": "ID075_ConyCony"
+		},
+		{
+			"id": 76,
+			"name": "ID076_ConyCony"
+		},
+		{
+			"id": 77,
+			"name": "ID077_ConyCony"
+		},
+		{
+			"id": 78,
+			"name": "ID078_ConyCony"
+		},
+		{
+			"id": 79,
+			"name": "ID079_ConyCony"
+		},
+		{
+			"id": 80,
+			"name": "ID080_ConyCony"
+		},
+		{
+			"id": 81,
+			"name": "ID081_NoBrand"
+		},
+		{
+			"id": 82,
+			"name": "ID082_ShepherdHouse"
+		},
+		{
+			"id": 83,
+			"name": "ID083_ShepherdHouse"
+		},
+		{
+			"id": 84,
+			"name": "ID084_ShepherdHouse"
+		},
+		{
+			"id": 85,
+			"name": "ID085_ShepherdHouse"
+		},
+		{
+			"id": 86,
+			"name": "ID086_ShepherdHouse"
+		},
+		{
+			"id": 87,
+			"name": "ID087_ShepherdHouse"
+		},
+		{
+			"id": 88,
+			"name": "ID088_ShepherdHouse"
+		},
+		{
+			"id": 89,
+			"name": "ID089_NoBrand"
+		},
+		{
+			"id": 90,
+			"name": "ID090_garagara"
+		},
+		{
+			"id": 91,
+			"name": "ID091_garagara"
+		},
+		{
+			"id": 92,
+			"name": "ID092_garagara"
+		},
+		{
+			"id": 93,
+			"name": "ID093_garagara"
+		},
+		{
+			"id": 94,
+			"name": "ID094_garagara"
+		},
+		{
+			"id": 95,
+			"name": "ID095_garagara"
+		},
+		{
+			"id": 96,
+			"name": "ID096_garagara"
+		},
+		{
+			"id": 97,
+			"name": "ID097_garagara"
+		},
+		{
+			"id": 98,
+			"name": "ID098_croakypanic"
+		},
+		{
+			"id": 99,
+			"name": "ID099_croakypanic"
+		},
+		{
+			"id": 100,
+			"name": "ID100_JupiterOfTheMonkey"
+		},
+		{
+			"id": 101,
+			"name": "ID101_JupiterOfTheMonkey"
+		},
+		{
+			"id": 102,
+			"name": "ID102_JupiterOfTheMonkey"
+		},
+		{
+			"id": 103,
+			"name": "ID103_JupiterOfTheMonkey"
+		},
+		{
+			"id": 104,
+			"name": "ID104_JupiterOfTheMonkey"
+		},
+		{
+			"id": 105,
+			"name": "ID105_JupiterOfTheMonkey"
+		},
+		{
+			"id": 106,
+			"name": "ID106_NoBrand"
+		},
+		{
+			"id": 107,
+			"name": "ID107_ILCAVALLODELRE"
+		},
+		{
+			"id": 108,
+			"name": "ID108_ILCAVALLODELRE"
+		},
+		{
+			"id": 109,
+			"name": "ID109_ILCAVALLODELRE"
+		},
+		{
+			"id": 110,
+			"name": "ID110_ILCAVALLODELRE"
+		},
+		{
+			"id": 111,
+			"name": "ID111_ILCAVALLODELRE"
+		},
+		{
+			"id": 112,
+			"name": "ID112_ILCAVALLODELRE"
+		},
+		{
+			"id": 113,
+			"name": "ID113_ILCAVALLODELRE"
+		},
+		{
+			"id": 114,
+			"name": "ID114_ILCAVALLODELRE"
+		},
+		{
+			"id": 115,
+			"name": "ID115_ILCAVALLODELRE"
+		},
+		{
+			"id": 116,
+			"name": "ID116_ILCAVALLODELRE"
+		},
+		{
+			"id": 117,
+			"name": "ID117_ILCAVALLODELRE"
+		},
+		{
+			"id": 118,
+			"name": "ID118_ILCAVALLODELRE"
+		},
+		{
+			"id": 119,
+			"name": "ID119_ILCAVALLODELRE"
+		},
+		{
+			"id": 120,
+			"name": "ID120_ILCAVALLODELRE"
+		},
+		{
+			"id": 121,
+			"name": "ID121_NoBrand"
+		},
+		{
+			"id": 122,
+			"name": "ID122_Jolibecot"
+		},
+		{
+			"id": 123,
+			"name": "ID123_Jolibecot"
+		},
+		{
+			"id": 124,
+			"name": "ID124_Jolibecot"
+		},
+		{
+			"id": 125,
+			"name": "ID125_Jolibecot"
+		},
+		{
+			"id": 126,
+			"name": "ID126_Jolibecot"
+		},
+		{
+			"id": 127,
+			"name": "ID127_Jolibecot"
+		},
+		{
+			"id": 128,
+			"name": "ID128_Jolibecot"
+		},
+		{
+			"id": 129,
+			"name": "ID129_Jolibecot"
+		},
+		{
+			"id": 130,
+			"name": "ID130_NoBrand"
+		},
+		{
+			"id": 131,
+			"name": "ID131_Jolibecot"
+		},
+		{
+			"id": 132,
+			"name": "ID132_Jolibecot"
+		},
+		{
+			"id": 133,
+			"name": "ID133_Jolibecot"
+		},
+		{
+			"id": 134,
+			"name": "ID134_Jolibecot"
+		},
+		{
+			"id": 135,
+			"name": "ID135_Jolibecot"
+		},
+		{
+			"id": 136,
+			"name": "ID136_Jolibecot"
+		},
+		{
+			"id": 137,
+			"name": "ID137_NoBrand"
+		},
+		{
+			"id": 138,
+			"name": "ID138_Jolibecot"
+		},
+		{
+			"id": 139,
+			"name": "ID139_Jolibecot"
+		},
+		{
+			"id": 140,
+			"name": "ID140_Jolibecot"
+		},
+		{
+			"id": 141,
+			"name": "ID141_ConyCony"
+		},
+		{
+			"id": 142,
+			"name": "ID142_ConyCony"
+		},
+		{
+			"id": 143,
+			"name": "ID143_ConyCony"
+		},
+		{
+			"id": 144,
+			"name": "ID144_ConyCony"
+		},
+		{
+			"id": 145,
+			"name": "ID145_ConyCony"
+		},
+		{
+			"id": 146,
+			"name": "ID146_ConyCony"
+		},
+		{
+			"id": 147,
+			"name": "ID147_ConyCony"
+		},
+		{
+			"id": 148,
+			"name": "ID148_ConyCony"
+		},
+		{
+			"id": 149,
+			"name": "ID149_NoBrand"
+		},
+		{
+			"id": 150,
+			"name": "ID150_TopoTopo"
+		},
+		{
+			"id": 151,
+			"name": "ID151_TopoTopo"
+		},
+		{
+			"id": 152,
+			"name": "ID152_TopoTopo"
+		},
+		{
+			"id": 153,
+			"name": "ID153_TopoTopo"
+		},
+		{
+			"id": 154,
+			"name": "ID154_TopoTopo"
+		},
+		{
+			"id": 155,
+			"name": "ID155_TopoTopo"
+		},
+		{
+			"id": 156,
+			"name": "ID156_TopoTopo"
+		},
+		{
+			"id": 157,
+			"name": "ID157_TopoTopo"
+		},
+		{
+			"id": 158,
+			"name": "ID158_TopoTopo"
+		},
+		{
+			"id": 159,
+			"name": "ID159_NoBrand"
+		},
+		{
+			"id": 160,
+			"name": "ID160_RyuGu"
+		},
+		{
+			"id": 161,
+			"name": "ID161_RyuGu"
+		},
+		{
+			"id": 162,
+			"name": "ID162_RyuGu"
+		},
+		{
+			"id": 163,
+			"name": "ID163_RyuGu"
+		},
+		{
+			"id": 164,
+			"name": "ID164_RyuGu"
+		},
+		{
+			"id": 165,
+			"name": "ID165_RyuGu"
+		},
+		{
+			"id": 166,
+			"name": "ID166_RyuGu"
+		},
+		{
+			"id": 167,
+			"name": "ID167_RyuGu"
+		},
+		{
+			"id": 168,
+			"name": "ID168_croakypanic"
+		},
+		{
+			"id": 169,
+			"name": "ID169_RyuGu"
+		},
+		{
+			"id": 170,
+			"name": "ID170_RyuGu"
+		},
+		{
+			"id": 171,
+			"name": "ID171_RyuGu"
+		},
+		{
+			"id": 172,
+			"name": "ID172_croakypanic"
+		},
+		{
+			"id": 173,
+			"name": "ID173_RyuGu"
+		},
+		{
+			"id": 174,
+			"name": "ID174_NoBrand"
+		},
+		{
+			"id": 175,
+			"name": "ID175_ConyCony"
+		},
+		{
+			"id": 176,
+			"name": "ID176_ConyCony"
+		},
+		{
+			"id": 177,
+			"name": "ID177_croakypanic"
+		},
+		{
+			"id": 178,
+			"name": "ID178_croakypanic"
+		},
+		{
+			"id": 179,
+			"name": "ID179_ConyCony"
+		},
+		{
+			"id": 180,
+			"name": "ID180_ConyCony"
+		},
+		{
+			"id": 181,
+			"name": "ID181_ConyCony"
+		},
+		{
+			"id": 182,
+			"name": "ID182_NoBrand"
+		},
+		{
+			"id": 183,
+			"name": "ID183_TopoTopo"
+		},
+		{
+			"id": 184,
+			"name": "ID184_TopoTopo"
+		},
+		{
+			"id": 185,
+			"name": "ID185_TopoTopo"
+		},
+		{
+			"id": 186,
+			"name": "ID186_croakypanic"
+		},
+		{
+			"id": 187,
+			"name": "ID187_croakypanic"
+		},
+		{
+			"id": 188,
+			"name": "ID188_TopoTopo"
+		},
+		{
+			"id": 189,
+			"name": "ID189_TopoTopo"
+		},
+		{
+			"id": 190,
+			"name": "ID190_ILCAVALLODELRE"
+		},
+		{
+			"id": 191,
+			"name": "ID191_ILCAVALLODELRE"
+		},
+		{
+			"id": 192,
+			"name": "ID192_ILCAVALLODELRE"
+		},
+		{
+			"id": 193,
+			"name": "ID193_ILCAVALLODELRE"
+		},
+		{
+			"id": 194,
+			"name": "ID194_ILCAVALLODELRE"
+		},
+		{
+			"id": 195,
+			"name": "ID195_NoBrand"
+		},
+		{
+			"id": 196,
+			"name": "ID196_HogFang"
+		},
+		{
+			"id": 197,
+			"name": "ID197_HogFang"
+		},
+		{
+			"id": 198,
+			"name": "ID198_HogFang"
+		},
+		{
+			"id": 199,
+			"name": "ID199_HogFang"
+		},
+		{
+			"id": 200,
+			"name": "ID200_HogFang"
+		},
+		{
+			"id": 201,
+			"name": "ID201_HogFang"
+		},
+		{
+			"id": 202,
+			"name": "ID202_HogFang"
+		},
+		{
+			"id": 203,
+			"name": "ID203_HogFang"
+		},
+		{
+			"id": 204,
+			"name": "ID204_HogFang"
+		},
+		{
+			"id": 205,
+			"name": "ID205_HogFang"
+		},
+		{
+			"id": 206,
+			"name": "ID206_NoBrand"
+		},
+		{
+			"id": 207,
+			"name": "ID207_RyuGu"
+		},
+		{
+			"id": 208,
+			"name": "ID208_RyuGu"
+		},
+		{
+			"id": 209,
+			"name": "ID209_RyuGu"
+		},
+		{
+			"id": 210,
+			"name": "ID210_RyuGu"
+		},
+		{
+			"id": 211,
+			"name": "ID211_NoBrand"
+		},
+		{
+			"id": 212,
+			"name": "ID212_RyuGu"
+		},
+		{
+			"id": 213,
+			"name": "ID213_RyuGu"
+		},
+		{
+			"id": 214,
+			"name": "ID214_RyuGu"
+		},
+		{
+			"id": 215,
+			"name": "ID215_RyuGu"
+		},
+		{
+			"id": 216,
+			"name": "ID216_TopoTopo"
+		},
+		{
+			"id": 217,
+			"name": "ID217_TopoTopo"
+		},
+		{
+			"id": 218,
+			"name": "ID218_TopoTopo"
+		},
+		{
+			"id": 219,
+			"name": "ID219_TopoTopo"
+		},
+		{
+			"id": 220,
+			"name": "ID220_TopoTopo"
+		},
+		{
+			"id": 221,
+			"name": "ID221_TopoTopo"
+		},
+		{
+			"id": 222,
+			"name": "ID222_TopoTopo"
+		},
+		{
+			"id": 223,
+			"name": "ID223_TopoTopo"
+		},
+		{
+			"id": 224,
+			"name": "ID224_TopoTopo"
+		},
+		{
+			"id": 225,
+			"name": "ID225_TopoTopo"
+		},
+		{
+			"id": 226,
+			"name": "ID226_NoBrand"
+		},
+		{
+			"id": 227,
+			"name": "ID227_NATURALPUPPY"
+		},
+		{
+			"id": 228,
+			"name": "ID228_NATURALPUPPY"
+		},
+		{
+			"id": 229,
+			"name": "ID229_NATURALPUPPY"
+		},
+		{
+			"id": 230,
+			"name": "ID230_NATURALPUPPY"
+		},
+		{
+			"id": 231,
+			"name": "ID231_NATURALPUPPY"
+		},
+		{
+			"id": 232,
+			"name": "ID232_MONOCROW"
+		},
+		{
+			"id": 233,
+			"name": "ID233_croakypanic"
+		},
+		{
+			"id": 234,
+			"name": "ID234_croakypanic"
+		},
+		{
+			"id": 235,
+			"name": "ID235_croakypanic"
+		},
+		{
+			"id": 236,
+			"name": "ID236_croakypanic"
+		},
+		{
+			"id": 237,
+			"name": "ID237_croakypanic"
+		},
+		{
+			"id": 238,
+			"name": "ID238_NoBrand"
+		},
+		{
+			"id": 239,
+			"name": "ID239_NoBrand"
+		},
+		{
+			"id": 240,
+			"name": "ID240_RyuGu"
+		},
+		{
+			"id": 241,
+			"name": "ID241_RyuGu"
+		},
+		{
+			"id": 242,
+			"name": "ID242_RyuGu"
+		},
+		{
+			"id": 243,
+			"name": "ID243_NoBrand"
+		},
+		{
+			"id": 244,
+			"name": "ID244_ShepherdHouse"
+		},
+		{
+			"id": 245,
+			"name": "ID245_ShepherdHouse"
+		},
+		{
+			"id": 246,
+			"name": "ID246_ShepherdHouse"
+		},
+		{
+			"id": 247,
+			"name": "ID247_ShepherdHouse"
+		},
+		{
+			"id": 248,
+			"name": "ID248_ShepherdHouse"
+		},
+		{
+			"id": 249,
+			"name": "ID249_ShepherdHouse"
+		},
+		{
+			"id": 250,
+			"name": "ID250_croakypanic"
+		},
+		{
+			"id": 251,
+			"name": "ID251_croakypanic"
+		},
+		{
+			"id": 252,
+			"name": "ID252_ShepherdHouse"
+		},
+		{
+			"id": 253,
+			"name": "ID253_ShepherdHouse"
+		},
+		{
+			"id": 254,
+			"name": "ID254_ShepherdHouse"
+		},
+		{
+			"id": 255,
+			"name": "ID255_ShepherdHouse"
+		},
+		{
+			"id": 256,
+			"name": "ID256_ShepherdHouse"
+		},
+		{
+			"id": 257,
+			"name": "ID257_garagara"
+		},
+		{
+			"id": 258,
+			"name": "ID258_garagara"
+		},
+		{
+			"id": 259,
+			"name": "ID259_garagara"
+		},
+		{
+			"id": 260,
+			"name": "ID260_garagara"
+		},
+		{
+			"id": 261,
+			"name": "ID261_garagara"
+		},
+		{
+			"id": 262,
+			"name": "ID262_garagara"
+		},
+		{
+			"id": 263,
+			"name": "ID263_garagara"
+		},
+		{
+			"id": 264,
+			"name": "ID264_garagara"
+		},
+		{
+			"id": 265,
+			"name": "ID265_garagara"
+		},
+		{
+			"id": 266,
+			"name": "ID266_garagara"
+		},
+		{
+			"id": 267,
+			"name": "ID267_garagara"
+		},
+		{
+			"id": 268,
+			"name": "ID268_NoBrand"
+		},
+		{
+			"id": 269,
+			"name": "ID269_HogFang"
+		},
+		{
+			"id": 270,
+			"name": "ID270_HogFang"
+		},
+		{
+			"id": 271,
+			"name": "ID271_HogFang"
+		},
+		{
+			"id": 272,
+			"name": "ID272_HogFang"
+		},
+		{
+			"id": 273,
+			"name": "ID273_HogFang"
+		},
+		{
+			"id": 274,
+			"name": "ID274_HogFang"
+		},
+		{
+			"id": 275,
+			"name": "ID275_HogFang"
+		},
+		{
+			"id": 276,
+			"name": "ID276_NoBrand"
+		},
+		{
+			"id": 277,
+			"name": "ID277_TigrePUNKS"
+		},
+		{
+			"id": 278,
+			"name": "ID278_TigrePUNKS"
+		},
+		{
+			"id": 279,
+			"name": "ID279_TigrePUNKS"
+		},
+		{
+			"id": 280,
+			"name": "ID280_TigrePUNKS"
+		},
+		{
+			"id": 281,
+			"name": "ID281_TigrePUNKS"
+		},
+		{
+			"id": 282,
+			"name": "ID282_TigrePUNKS"
+		},
+		{
+			"id": 283,
+			"name": "ID283_TigrePUNKS"
+		},
+		{
+			"id": 284,
+			"name": "ID284_NoBrand"
+		},
+		{
+			"id": 285,
+			"name": "ID285_MONOCROW"
+		},
+		{
+			"id": 286,
+			"name": "ID286_MONOCROW"
+		},
+		{
+			"id": 287,
+			"name": "ID287_MONOCROW"
+		},
+		{
+			"id": 288,
+			"name": "ID288_MONOCROW"
+		},
+		{
+			"id": 289,
+			"name": "ID289_Jolibecot"
+		},
+		{
+			"id": 290,
+			"name": "ID290_Jolibecot"
+		},
+		{
+			"id": 291,
+			"name": "ID291_NoBrand"
+		},
+		{
+			"id": 292,
+			"name": "ID292_GattoNero"
+		},
+		{
+			"id": 293,
+			"name": "ID293_GattoNero"
+		},
+		{
+			"id": 294,
+			"name": "ID294_GattoNero"
+		},
+		{
+			"id": 295,
+			"name": "ID295_GattoNero"
+		},
+		{
+			"id": 296,
+			"name": "ID296_GattoNero"
+		},
+		{
+			"id": 297,
+			"name": "ID297_GattoNero"
+		},
+		{
+			"id": 298,
+			"name": "ID298_GattoNero"
+		},
+		{
+			"id": 299,
+			"name": "ID299_GattoNero"
+		},
+		{
+			"id": 300,
+			"name": "ID300_GattoNero"
+		},
+		{
+			"id": 301,
+			"name": "ID301_GattoNero"
+		},
+		{
+			"id": 302,
+			"name": "ID302_GattoNero"
+		},
+		{
+			"id": 303,
+			"name": "ID303_GattoNero"
+		},
+		{
+			"id": 304,
+			"name": "ID304_NoBrand"
+		},
+		{
+			"id": 305,
+			"name": "ID305_NoBrand"
+		},
+		{
+			"id": 306,
+			"name": "ID306_NoBrand"
+		},
+		{
+			"id": 307,
+			"name": "ID307_JupiterOfTheMonkey"
+		},
+		{
+			"id": 308,
+			"name": "ID308_JupiterOfTheMonkey"
+		},
+		{
+			"id": 309,
+			"name": "ID309_NoBrand"
+		},
+		{
+			"id": 310,
+			"name": "ID310_NoBrand"
+		},
+		{
+			"id": 311,
+			"name": "ID311_NoBrand"
+		},
+		{
+			"id": 312,
+			"name": "ID312_NoBrand"
+		},
+		{
+			"id": 313,
+			"name": "ID323_sozai"
+		},
+		{
+			"id": 314,
+			"name": "ID324_sozai"
+		},
+		{
+			"id": 315,
+			"name": "ID325_sozai"
+		},
+		{
+			"id": 316,
+			"name": "ID326_sozai"
+		},
+		{
+			"id": 317,
+			"name": "ID327_sozai"
+		},
+		{
+			"id": 318,
+			"name": "ID328_sozai"
+		},
+		{
+			"id": 319,
+			"name": "ID329_sozai"
+		},
+		{
+			"id": 320,
+			"name": "ID330_sozai"
+		},
+		{
+			"id": 321,
+			"name": "ID331_sozai"
+		},
+		{
+			"id": 322,
+			"name": "ID332_sozai"
+		},
+		{
+			"id": 323,
+			"name": "ID333_sozai"
+		}
 	]
 }

--- a/Resources/settings_string_versions.json
+++ b/Resources/settings_string_versions.json
@@ -1,0 +1,225 @@
+{
+	"versions": [
+		{
+			"version": 0,
+			"values": {
+				"dropped_pin_category": {
+					"name": "dropped_pin_category",
+					"offset": 4,
+					"size": 3
+				},
+				"dropped_pin_limited": {
+					"name": "dropped_pin_limited",
+					"offset": 7,
+					"size": 1
+				},
+				"dropped_pin_easy": {
+					"name": "dropped_pin_easy",
+					"offset": 8,
+					"size": 1
+				},
+				"dropped_pin_normal": {
+					"name": "dropped_pin_normal",
+					"offset": 9,
+					"size": 1
+				},
+				"dropped_pin_hard": {
+					"name": "dropped_pin_hard",
+					"offset": 10,
+					"size": 1
+				},
+				"dropped_pin_ultimate": {
+					"name": "dropped_pin_ultimate",
+					"offset": 11,
+					"size": 1
+				},
+				"drop_rate_category": {
+					"name": "drop_rate_category",
+					"offset": 12,
+					"size": 2
+				},
+				"drop_rate_minimum": {
+					"name": "drop_rate_minimum",
+					"offset": 14,
+					"size": 14
+				},
+				"drop_rate_maximum": {
+					"name": "drop_rate_maximum",
+					"offset": 28,
+					"size": 14
+				},
+				"drop_rate_easy": {
+					"name": "drop_rate_easy",
+					"offset": 42,
+					"size": 1
+				},
+				"drop_rate_normal": {
+					"name": "drop_rate_normal",
+					"offset": 43,
+					"size": 1
+				},
+				"drop_rate_hard": {
+					"name": "drop_rate_hard",
+					"offset": 44,
+					"size": 1
+				},
+				"drop_rate_ultimate": {
+					"name": "drop_rate_ultimate",
+					"offset": 45,
+					"size": 1
+				},
+				"drop_rate_easy_weight": {
+					"name": "drop_rate_easy_weight",
+					"offset": 46,
+					"size": 7
+				},
+				"drop_rate_normal_weight": {
+					"name": "drop_rate_normal_weight",
+					"offset": 53,
+					"size": 7
+				},
+				"drop_rate_hard_weight": {
+					"name": "drop_rate_hard_weight",
+					"offset": 60,
+					"size": 7
+				},
+				"drop_rate_ultimate_weight": {
+					"name": "drop_rate_ultimate_weight",
+					"offset": 67,
+					"size": 7
+				},
+				"pin_power": {
+					"name": "pin_power",
+					"offset": 74,
+					"size": 1
+				},
+				"pin_power_scaling": {
+					"name": "pin_power_scaling",
+					"offset": 75,
+					"size": 1
+				},
+				"pin_limit": {
+					"name": "pin_limit",
+					"offset": 76,
+					"size": 1
+				},
+				"pin_limit_scaling": {
+					"name": "pin_limit_scaling",
+					"offset": 77,
+					"size": 1
+				},
+				"pin_reboot": {
+					"name": "pin_reboot",
+					"offset": 78,
+					"size": 1
+				},
+				"pin_reboot_scaling": {
+					"name": "pin_reboot_scaling",
+					"offset": 79,
+					"size": 1
+				},
+				"pin_boot": {
+					"name": "pin_boot",
+					"offset": 80,
+					"size": 1
+				},
+				"pin_boot_scaling": {
+					"name": "pin_boot_scaling",
+					"offset": 81,
+					"size": 1
+				},
+				"pin_recover": {
+					"name": "pin_recover",
+					"offset": 82,
+					"size": 1
+				},
+				"pin_recover_scaling": {
+					"name": "pin_recover_scaling",
+					"offset": 83,
+					"size": 1
+				},
+				"pin_charge": {
+					"name": "pin_charge",
+					"offset": 84,
+					"size": 1
+				},
+				"pin_sell": {
+					"name": "pin_sell",
+					"offset": 85,
+					"size": 1
+				},
+				"pin_sell_scaling": {
+					"name": "pin_sell_scaling",
+					"offset": 86,
+					"size": 1
+				},
+				"pin_affinity": {
+					"name": "pin_affinity",
+					"offset": 87,
+					"size": 1
+				},
+				"pin_level": {
+					"name": "pin_level",
+					"offset": 88,
+					"size": 1
+				},
+				"pin_brand_category": {
+					"name": "pin_brand_category",
+					"offset": 89,
+					"size": 2
+				},
+				"pin_uber": {
+					"name": "pin_uber",
+					"offset": 91,
+					"size": 1
+				},
+				"pin_uber_percent": {
+					"name": "pin_uber_percent",
+					"offset": 92,
+					"size": 7
+				},
+				"pin_ability_category": {
+					"name": "pin_ability_category",
+					"offset": 99,
+					"size": 2
+				},
+				"pin_ability_percent": {
+					"name": "pin_ability_percent",
+					"offset": 101,
+					"size": 7
+				},
+				"pin_growth_category": {
+					"name": "pin_growth_category",
+					"offset": 108,
+					"size": 2
+				},
+				"pin_growth_specific": {
+					"name": "pin_growth_specific",
+					"offset": 110,
+					"size": 3
+				},
+				"pin_evo_category": {
+					"name": "pin_evo_category",
+					"offset": 113,
+					"size": 2
+				},
+				"pin_evo_force": {
+					"name": "pin_evo_force",
+					"offset": 115,
+					"size": 1
+				},
+				"pin_evo_chara": {
+					"name": "pin_evo_chara",
+					"offset": 116,
+					"size": 1
+				},
+				"pin_evo_percent": {
+					"name": "pin_evo_percent",
+					"offset": 117,
+					"size": 7
+				}
+			},
+			"changed_values": []
+		}
+	]
+}


### PR DESCRIPTION
- Made Settings Strings mostly backwards compatible, with a warning for which settings will be broken by using the older string.
- This also adds an error message for if the version used is of a newer (or invalid) version of the Randomizer. In that case, the string cannot be used.
- Optimized the way the random pin image is loaded at startup.